### PR TITLE
Fix/mediator bug

### DIFF
--- a/docker-compose.public.yml
+++ b/docker-compose.public.yml
@@ -15,7 +15,7 @@ services:
       LOG_LEVEL: DEBUG
 
   agent:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.2
+    image: dbluhm/acapy:fix-mediation-073
     volumes:
       - indy:/home/indy/.indy_client
     command: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,7 @@ services:
     entrypoint: /bin/sh -c '/app/wait && python -m proxy_mediator "$$@"' --
 
   agent:
-    #image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
-    image: dbluhm/acapy:fix-default-mediator
+    image: dbluhm/acapy:fix-mediation-073
     volumes:
       - indy:/home/indy/.indy_client
     command: >

--- a/int/docker-compose.yml
+++ b/int/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       LOG_LEVEL: DEBUG
 
   agent_alice:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
+    image: dbluhm/acapy:fix-mediation-073
     command: >
       start --label agent_alice -it http 0.0.0.0 4011 -ot http -e http://agent_alice:4011
       --no-ledger --admin 0.0.0.0 4001 --admin-insecure-mode
@@ -26,7 +26,7 @@ services:
 
 
   agent_bob:
-    image: bcgovimages/aries-cloudagent:py36-1.16-1_0.7.1
+    image: dbluhm/acapy:fix-mediation-073
     command: >
       start --label agent_bob -it http 0.0.0.0 4012 -ot http -e http://agent_bob:4012
       --no-ledger --admin 0.0.0.0 4002 --admin-insecure-mode

--- a/int/tests/test_proxy_mediator_connections.py
+++ b/int/tests/test_proxy_mediator_connections.py
@@ -80,8 +80,8 @@ async def test_connection_from_alice(
     await record_state("active", partial(_retrieve, receiver, connection.connection_id))
 
     endpoint_retrieved = await get_connections_conn_id_endpoints.asyncio(
-        conn_id=invite.connection_id,
-        client=sender,
+        conn_id=connection.connection_id,
+        client=receiver,
     )
     assert endpoint_retrieved
-    assert endpoint_retrieved.my_endpoint == endpoint
+    assert endpoint_retrieved.their_endpoint == endpoint

--- a/int/tests/test_proxy_mediator_connections.py
+++ b/int/tests/test_proxy_mediator_connections.py
@@ -6,6 +6,7 @@ from acapy_client.api.connection import (
     create_invitation,
     get_connection,
     receive_invitation,
+    get_connections_conn_id_endpoints,
 )
 from acapy_client.models.conn_record import ConnRecord
 from acapy_client.models.create_invitation_request import CreateInvitationRequest
@@ -77,3 +78,10 @@ async def test_connection_from_alice(
 
     await record_state("active", partial(_retrieve, sender, invite.connection_id))
     await record_state("active", partial(_retrieve, receiver, connection.connection_id))
+
+    endpoint_retrieved = await get_connections_conn_id_endpoints.asyncio(
+        conn_id=invite.connection_id,
+        client=sender,
+    )
+    assert endpoint_retrieved
+    assert endpoint_retrieved.my_endpoint == endpoint


### PR DESCRIPTION
This PR adds an endpoint check to the `test_proxy_mediation_connections` integration test. It updates the agent `docker-compose` configurations to use an ACA-Py 0.7.3 image with a mediation fix. This image fixes the bug in which the connection response does not include the proper mediator information associated with it, even if the invitation and connection request are correctly mediated.